### PR TITLE
Add whois server for .racing

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -560,6 +560,7 @@
   {"zone": ".qpon", "host": "whois.nic.qpon"},
   {"zone": ".quebec", "host": "whois.nic.quebec"},
   {"zone": ".quebec", "host": "whois.quebec.rs.corenic.net"},
+  {"zone": ".racing", "host": "whois.nic.racing"},
   {"zone": ".re", "host": "whois.nic.re"},
   {"zone": ".recipes", "host": "whois.donuts.co"},
   {"zone": ".red", "host": "whois.afilias.net"},

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -677,6 +677,10 @@ class TldParsingTest extends TestCase
             [ "free.qa", ".qa/free.txt", null ],
             [ "google.com.qa", ".qa/google.com.qa.txt", ".qa/google.com.qa.json" ],
 
+            // .RACING
+            [ "free.racing", ".racing/free.txt", null ],
+            [ "google.racing", ".racing/google.racing.txt", ".racing/google.racing.json" ],
+
             // .REN
             [ "free.ren", ".ren/free.txt", null ],
             [ "nic.ren", ".ren/nic.ren.txt", ".ren/nic.ren.json" ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.racing/free.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.racing/free.txt
@@ -1,0 +1,35 @@
+The queried object does not exist: free.ren
+>>> Last update of WHOIS database: 2020-05-06T07:27:42Z <<<
+
+Status Codes: For more information on Whois status codes, please visit https://icann.org/epp
+
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
+view the registrar's reported date of expiration for this registration.
+
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in KNET Global Registry
+Services' ("KNET") Whois database is provided by KNET for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. KNET does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to KNET (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of KNET. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. KNET reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  KNET may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. KNET
+reserves the right to modify these terms at any time.

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.racing/google.racing.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.racing/google.racing.json
@@ -1,0 +1,17 @@
+{
+  "domainName": "google.racing",
+  "whoisServer": "whois.markmonitor.com",
+  "nameServers": [],
+  "dnssec": "unsigned",
+  "creationDate": "2015-08-03T15:10:08Z",
+  "expirationDate": "2021-08-02T23:59:59Z",
+  "updatedDate": "2020-07-06T09:35:03Z",
+  "states": [
+    "clientupdateprohibited",
+    "clientdeleteprohibited",
+    "clienttransferprohibited",
+    "inactive"
+  ],
+  "owner": "Google LLC",
+  "registrar": "MarkMonitor, Inc."
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.racing/google.racing.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.racing/google.racing.txt
@@ -1,0 +1,84 @@
+Domain Name: google.racing
+Registry Domain ID: D2823-RACING
+Registrar WHOIS Server: whois.markmonitor.com
+Registrar URL: www.markmonitor.com
+Updated Date: 2020-07-06T09:35:03Z
+Creation Date: 2015-08-03T15:10:08Z
+Registry Expiry Date: 2021-08-02T23:59:59Z
+Registrar: MarkMonitor, Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: inactive https://icann.org/epp#inactive
+Registry Registrant ID:
+Registrant Name:
+Registrant Organization: Google LLC
+Registrant Street:
+Registrant Street:
+Registrant Street:
+Registrant City:
+Registrant State/Province: CA
+Registrant Postal Code:
+Registrant Country: US
+Registrant Phone:
+Registrant Phone Ext:
+Registrant Fax:
+Registrant Fax Ext:
+Registrant Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Admin ID:
+Admin Name:
+Admin Organization:
+Admin Street:
+Admin Street:
+Admin Street:
+Admin City:
+Admin State/Province:
+Admin Postal Code:
+Admin Country:
+Admin Phone:
+Admin Phone Ext:
+Admin Fax:
+Admin Fax Ext:
+Admin Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Tech ID:
+Tech Name:
+Tech Organization:
+Tech Street:
+Tech Street:
+Tech Street:
+Tech City:
+Tech State/Province:
+Tech Postal Code:
+Tech Country:
+Tech Phone:
+Tech Phone Ext:
+Tech Fax:
+Tech Fax Ext:
+Tech Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Name Server:
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2020-10-07T07:14:31Z <<<
+The above WHOIS results have been redacted to remove potential personal data. The full WHOIS output may be available to individuals and organisations with a legitimate interest in accessing this data not outweighed by the fundamental privacy rights of the data subject. To find out more, or to make a request for access, please visit: RDDSrequest.nic.racing.
+For more information on Whois status codes, please visit https://icann.org/epp
+
+The WHOIS service offered by the Registry Operator, and the access to the records in the Registry Operator WHOIS database, are provided for information purposes only and is designed (i) to assist persons in determining whether a specific domain name registration record is available or not in the Registry Operator database and (ii) to obtain information related to the registration records of existing domain names.  The Registry Operator cannot, under any circumstances, be held liable in such instances where the stored information would prove to be wrong, incomplete, or not accurate in any sense.
+By submitting a WHOIS query, you, the user, agree that you will not use this data:
+(i)     to allow, enable or otherwise support in any way the transmission of unsolicited, commercial advertising or other solicitations whether via direct mail, email, telephone or otherwise;
+(ii)    to enable high volume, automated, electronic processes that apply to the registry (or its systems);
+(iii)   for target advertising in any possible way;
+(iv)    to cause nuisance in any possible way to the registrants by sending (whether by automated, electronic processes capable of enabling high volumes or other possible means) messages to them;
+(v)     to violate any law, rule, regulation or statute; and/or
+(vi)    in contravention of any applicable data and privacy protection acts.
+
+Without prejudice to the above, it is explicitly forbidden to extract, copy and/or use or re-utilize in any form and by any means (electronically or not) the whole or a quantitatively or qualitatively substantial part of the contents of the WHOIS database without prior and explicit permission by Registry Operator, nor in any attempt hereof, or to apply automated, electronic processes to Registry Operator (or its systems or their designated third party Registry Service Provider's systems).
+
+You agree that any reproduction and/or transmission of data for commercial purposes will always be considered as the extraction of a substantial part of the content of the WHOIS database. By utilizing this website and/or submitting a query you agree to abide by this policy and accept that Registry Operator can take measures to limit the use of its WHOIS services in order to protect the privacy of its registrants or the integrity of the database.
+
+We reserve the right to make changes to these Terms and Conditions at any time without prior notice to you. It is your responsibility to review these Terms and Conditions each time you access or use the WHOIS service and to familiarise yourself with any changes. If you do not agree to the changes implemented by Registry Operator, your sole and exclusive remedy is to terminate your use of the WHOIS service.
+
+By executing a query, in any manner whatsoever, you agree to abide by these Terms and Conditions.
+NOTE: FAILURE TO LOCATE A RECORD IN THE WHOIS DATABASE IS NOT INDICATIVE OF THE AVAILABILITY OF A DOMAIN NAME.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please add use-case examples to README.md -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4
| License       | MIT

Whois server for .racing domains, according to iana.org.