### PR TITLE
Add whois server for . promo

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -550,6 +550,7 @@
   {"zone": ".prod", "host": "domain-registry-whois.l.google.com"},
   {"zone": ".productions", "host": "whois.donuts.co"},
   {"zone": ".prof", "host": "domain-registry-whois.l.google.com"},
+  {"zone": ".promo", "host": "whois.afilias.net"},
   {"zone": ".properties", "host": "whois.donuts.co"},
   {"zone": ".property", "host": "whois.uniregistry.net"},
   {"zone": ".ps", "host": "whois.pnina.ps"},

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -669,6 +669,10 @@ class TldParsingTest extends TestCase
             [ "free.pr", ".pr/free.txt", null ],
             [ "google.com.pr", ".pr/google.com.pr.txt", ".pr/google.com.pr.json" ],
 
+            // .PROMO
+            [ "free.promo", ".promo/free.txt", null ],
+            [ "google.promo", ".promo/google.promo.txt", ".promo/google.promo.json" ],
+
             // .PS
             [ "free.ps", ".ps/free.txt", null ],
             [ "google.ps", ".ps/google.ps.txt", ".ps/google.ps.json" ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.promo/free.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.promo/free.txt
@@ -1,0 +1,25 @@
+%
+% NIC.PR WHOIS server.
+%
+% Disclaimer
+% The data in NIC.PR's WHOIS database is provided to you by NIC.PR
+% for information purposes only, that is to assist you in obtaining
+% information about or related to a domain name registration record.
+% NIC.PR makes this information available "as is", and does not 
+% guarantee its accuracy. By submitting a WHOIS query, you agree that
+% you will use this data only for lawful purposes and that, under no
+% circumstances will you use this data to: (1) allow, enable, or 
+% otherwise support the transmission of mass unsolicited, commercial 
+% advertising or solicitations via direct mail, electronic mail, 
+% including spam or by telephone; or (2) enable high volume, 
+% automated, electronic processes or robotic, including mining this 
+% data for your own personal or commercial purposes that apply to 
+% NIC.PR (or its systems). The compilation, repackaging, dissemination
+% or other use of this data is expressly prohibited without the prior
+% written consent of NIC.PR. NIC.PR reserves the right to modify 
+% these terms at any time. By sub-mitting this query, you agree to 
+% abide by these terms.
+
+The domain free.pr is not registered.
+
+

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.promo/google.promo.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.promo/google.promo.json
@@ -1,0 +1,21 @@
+{
+  "domainName": "google.promo",
+  "whoisServer": "whois.markmonitor.com",
+  "nameServers": [
+    "ns3.googledomains.com",
+    "ns1.googledomains.com",
+    "ns2.googledomains.com",
+    "ns4.googledomains.com"
+  ],
+  "creationDate": "2016-04-26T15:59:09Z",
+  "expirationDate": "2021-04-26T15:59:09Z",
+  "updatedDate": "2020-03-25T09:40:04Z",
+  "states": [
+    "clientdeleteprohibited",
+    "clienttransferprohibited",
+    "clientupdateprohibited"
+  ],
+  "dnssec": "unsigned",
+  "owner": "Google LLC",
+  "registrar": "MarkMonitor Inc."
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.promo/google.promo.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.promo/google.promo.txt
@@ -1,0 +1,31 @@
+Domain Name: GOOGLE.PROMO
+Registry Domain ID: D503300000008270600-LRMS
+Registrar WHOIS Server: whois.markmonitor.com
+Registrar URL: http://www.markmonitor.com
+Updated Date: 2020-03-25T09:40:04Z
+Creation Date: 2016-04-26T15:59:09Z
+Registry Expiry Date: 2021-04-26T15:59:09Z
+Registrar Registration Expiration Date:
+Registrar: MarkMonitor Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Reseller:
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Registrant Organization: Google LLC
+Registrant State/Province: CA
+Registrant Country: US
+Name Server: NS3.GOOGLEDOMAINS.COM
+Name Server: NS1.GOOGLEDOMAINS.COM
+Name Server: NS2.GOOGLEDOMAINS.COM
+Name Server: NS4.GOOGLEDOMAINS.COM
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form is https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2020-10-07T07:58:43Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Access to AFILIAS WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Afilias registry database. The data in this record is provided by Afilias Limited for informational purposes only, and Afilias does not guarantee its accuracy.  This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to(a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Afilias reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.
+The Registrar of Record identified in this output may have an RDDS service that can be queried for additional information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please add use-case examples to README.md -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6 
| License       | MIT

Whois server for .promo domains, according to iana.org.
